### PR TITLE
general fixes and checkpoint state accessors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,34 @@
+linters:
+  enable:
+    - asciicheck
+    - dogsled
+    - dupl
+    - errcheck
+    - errorlint
+    - exportloopref
+    - gocognit
+    - goconst
+    - gocyclo
+    - gofmt
+    - goimports
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nakedret
+    - prealloc
+    - revive
+    - staticcheck
+    - stylecheck
+    - unconvert
+    - unused
+
+linters-settings:
+  goimports:
+    local-prefixes: consensus-shipyard/go-ipc-types
+  gocognit:
+    min-complexity: 50
+
+run:
+  timeout: 5m

--- a/gateway/types.go
+++ b/gateway/types.go
@@ -119,7 +119,7 @@ func NewCheckpoint(id sdk.SubnetID, epoch abi.ChainEpoch) *Checkpoint {
 
 func (c *Checkpoint) Cid() (cid.Cid, error) {
 	buf := new(bytes.Buffer)
-	if err := c.MarshalCBOR(buf); err != nil {
+	if err := c.Data.MarshalCBOR(buf); err != nil {
 		return cid.Undef, err
 	}
 	h, err := mh.Sum(buf.Bytes(), abi.HashFunction, -1)

--- a/gateway/types.go
+++ b/gateway/types.go
@@ -31,7 +31,7 @@ func (sn *Subnet) GetTopDownMsg(s adt.Store, nonce uint64) (*CrossMsg, bool, err
 }
 
 // GetWindowCheckpoint gets the template for a specific epoch. If no template is persisted
-// yet, and empty template is provided.
+// yet, an empty template is provided.
 //
 // NOTE: This function doesn't check if a template from the future is being requested.
 func (st *State) GetWindowCheckpoint(s adt.Store, epoch abi.ChainEpoch) (*Checkpoint, error) {

--- a/gateway/types.go
+++ b/gateway/types.go
@@ -3,10 +3,11 @@ package gateway
 import (
 	"bytes"
 
-	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/specs-actors/v7/actors/util/adt"
 	"github.com/ipfs/go-cid"
 	mh "github.com/multiformats/go-multihash"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/specs-actors/v7/actors/util/adt"
 
 	"github.com/consensus-shipyard/go-ipc-types/sdk"
 	"github.com/consensus-shipyard/go-ipc-types/utils"
@@ -30,22 +31,6 @@ func (sn *Subnet) GetTopDownMsg(s adt.Store, nonce uint64) (*CrossMsg, bool, err
 	return utils.GetOutOfArray[CrossMsg](sn.TopDownMsgs, s, nonce, CrossMsgsAMTBitwidth)
 }
 
-// GetWindowCheckpoint gets the template for a specific epoch. If no template is persisted
-// yet, an empty template is provided.
-//
-// NOTE: This function doesn't check if a template from the future is being requested.
-func (st *State) GetWindowCheckpoint(s adt.Store, epoch abi.ChainEpoch) (*Checkpoint, error) {
-	ch, found, err := utils.GetOutOfHamt[Checkpoint](st.Checkpoints, s,
-		abi.UIntKey(uint64(CheckpointEpoch(epoch, st.CheckPeriod))))
-	if err != nil {
-		return nil, err
-	}
-	if !found {
-		return NewCheckpoint(st.NetworkName, epoch), nil
-	}
-	return ch, nil
-}
-
 type StorableMsg struct {
 	From   sdk.IPCAddress
 	To     sdk.IPCAddress
@@ -58,7 +43,7 @@ type StorableMsg struct {
 func (sm *StorableMsg) IPCType() IPCMsgType {
 	toSubnetID := sm.To.SubnetID
 	fromSubnetID := sm.From.SubnetID
-	if sdk.IsBottomup(fromSubnetID, toSubnetID) {
+	if sdk.IsBottomUp(fromSubnetID, toSubnetID) {
 		return IPCMsgTypeBottomUp
 	}
 	return IPCMsgTypeTopDown
@@ -139,8 +124,8 @@ func (c *Checkpoint) CrossMsgMeta(from, to *sdk.SubnetID) (*CrossMsgMeta, bool) 
 	return nil, false
 }
 
-func (s *Checkpoint) CrossMsgMetaIndex(from, to *sdk.SubnetID) (int, bool) {
-	for i, m := range s.Data.CrossMsgs {
+func (c *Checkpoint) CrossMsgMetaIndex(from, to *sdk.SubnetID) (int, bool) {
+	for i, m := range c.Data.CrossMsgs {
 		if *from == m.From && *to == m.To {
 			return i, true
 		}

--- a/gateway/types.go
+++ b/gateway/types.go
@@ -115,24 +115,6 @@ func (c *Checkpoint) Cid() (cid.Cid, error) {
 	return cid.NewCidV1(abi.CidBuilder.GetCodec(), h), nil
 }
 
-func (c *Checkpoint) CrossMsgMeta(from, to *sdk.SubnetID) (*CrossMsgMeta, bool) {
-	for i, m := range c.Data.CrossMsgs {
-		if *from == m.From && *to == m.To {
-			return &c.Data.CrossMsgs[i], true
-		}
-	}
-	return nil, false
-}
-
-func (c *Checkpoint) CrossMsgMetaIndex(from, to *sdk.SubnetID) (int, bool) {
-	for i, m := range c.Data.CrossMsgs {
-		if *from == m.From && *to == m.To {
-			return i, true
-		}
-	}
-	return 0, false
-}
-
 func CheckpointEpoch(epoch, period abi.ChainEpoch) abi.ChainEpoch {
 	return (epoch / period) * period
 }

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -17,6 +17,7 @@ func main() {
 		gateway.ChildCheck{},
 		gateway.CrossMsgMeta{},
 		gateway.StorableMsg{},
+		gateway.Subnet{},
 		gateway.RawBytes{},
 		gateway.CrossMsg{},
 		gateway.FundParams{},

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	gen "github.com/whyrusleeping/cbor-gen"
+
 	"github.com/consensus-shipyard/go-ipc-types/gateway"
 	"github.com/consensus-shipyard/go-ipc-types/sdk"
 	"github.com/consensus-shipyard/go-ipc-types/subnetactor"
-	gen "github.com/whyrusleeping/cbor-gen"
 )
 
 func main() {

--- a/sdk/gen/gen.go
+++ b/sdk/gen/gen.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	sdk "github.com/consensus-shipyard/go-ipc-types/sdk"
 	gen "github.com/whyrusleeping/cbor-gen"
+
+	"github.com/consensus-shipyard/go-ipc-types/sdk"
 )
 
 func main() {

--- a/sdk/ipcaddress.go
+++ b/sdk/ipcaddress.go
@@ -11,7 +11,7 @@ import (
 // undefined IPC address
 var UndefIPCAddress = IPCAddress{}
 
-// Address adds subnet information to raw Filecoin addresses
+// IPCAddress adds subnet information to raw Filecoin addresses
 type IPCAddress struct {
 	SubnetID   SubnetID
 	RawAddress address.Address

--- a/sdk/ipcsdk_test.go
+++ b/sdk/ipcsdk_test.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/consensus-shipyard/go-ipc-types/sdk"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-address"
+
+	"github.com/consensus-shipyard/go-ipc-types/sdk"
 )
 
 func init() {
@@ -66,7 +67,7 @@ func TestCborMarshal(t *testing.T) {
 func TestHAddress(t *testing.T) {
 	address.CurrentNetwork = address.Mainnet
 	id, _ := address.NewIDAddress(1000)
-	a := sdk.IPCAddress{sdk.RootSubnet, id}
+	a := sdk.IPCAddress{SubnetID: sdk.RootSubnet, RawAddress: id}
 
 	sn := a.SubnetID
 	require.Equal(t, sdk.RootSubnet, sn)
@@ -131,6 +132,6 @@ func testParentAndBottomUp(t *testing.T, from, to, parent string, exl int, botto
 	require.NoError(t, err)
 	require.Equal(t, p, sparent)
 	require.Equal(t, exl, l)
-	require.Equal(t, sdk.IsBottomup(sFrom, sTo), bottomup)
+	require.Equal(t, sdk.IsBottomUp(sFrom, sTo), bottomup)
 
 }

--- a/sdk/subnetid.go
+++ b/sdk/subnetid.go
@@ -71,9 +71,8 @@ func (id SubnetID) String() string {
 	if id == RootSubnet {
 		if id.Parent != UndefStr {
 			return RootStr
-		} else {
-			return UndefStr
 		}
+		return UndefStr
 	}
 	return filepath.Join(id.Parent, id.Actor.String())
 }
@@ -152,7 +151,7 @@ func (id SubnetID) Up(curr SubnetID) SubnetID {
 	return sn
 }
 
-func IsBottomup(from SubnetID, to SubnetID) bool {
+func IsBottomUp(from SubnetID, to SubnetID) bool {
 	subnetID, index := from.CommonParent(to)
 	if subnetID == UndefSubnetID {
 		return false

--- a/sdk/subnetid.go
+++ b/sdk/subnetid.go
@@ -34,6 +34,10 @@ var UndefSubnetID = SubnetID{
 	Actor:  id0,
 }
 
+func (id SubnetID) Key() string {
+	return id.String()
+}
+
 func NewSubnetIDFromString(addr string) (SubnetID, error) {
 	var out SubnetID
 	if addr == RootSubnet.String() {
@@ -58,9 +62,8 @@ func NewSubnetID(parent SubnetID, subnetAct address.Address) SubnetID {
 	}
 }
 
-func (s SubnetID) Bytes() []byte {
-	strID := s.String()
-	return []byte(strID)
+func (id SubnetID) Bytes() []byte {
+	return []byte(id.String())
 }
 
 // String returns the id in string form.

--- a/subnetactor/cbor_gen.go
+++ b/subnetactor/cbor_gen.go
@@ -57,15 +57,10 @@ func (t *State) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Consensus (subnetactor.ConsensusType) (int64)
-	if t.Consensus >= 0 {
-		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Consensus)); err != nil {
-			return err
-		}
-	} else {
-		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.Consensus-1)); err != nil {
-			return err
-		}
+	// t.Consensus (subnetactor.ConsensusType) (uint64)
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Consensus)); err != nil {
+		return err
 	}
 
 	// t.MinValidatorStake (big.Int) (struct)
@@ -216,30 +211,19 @@ func (t *State) UnmarshalCBOR(r io.Reader) (err error) {
 		}
 
 	}
-	// t.Consensus (subnetactor.ConsensusType) (int64)
+	// t.Consensus (subnetactor.ConsensusType) (uint64)
+
 	{
-		maj, extra, err := cr.ReadHeader()
-		var extraI int64
+
+		maj, extra, err = cr.ReadHeader()
 		if err != nil {
 			return err
 		}
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative oveflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
 		}
+		t.Consensus = ConsensusType(extra)
 
-		t.Consensus = ConsensusType(extraI)
 	}
 	// t.MinValidatorStake (big.Int) (struct)
 
@@ -474,15 +458,10 @@ func (t *ConstructParams) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Consensus (subnetactor.ConsensusType) (int64)
-	if t.Consensus >= 0 {
-		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Consensus)); err != nil {
-			return err
-		}
-	} else {
-		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.Consensus-1)); err != nil {
-			return err
-		}
+	// t.Consensus (subnetactor.ConsensusType) (uint64)
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Consensus)); err != nil {
+		return err
 	}
 
 	// t.MinValidatorStake (big.Int) (struct)
@@ -589,30 +568,19 @@ func (t *ConstructParams) UnmarshalCBOR(r io.Reader) (err error) {
 		t.IpcGatewayAddr = uint64(extra)
 
 	}
-	// t.Consensus (subnetactor.ConsensusType) (int64)
+	// t.Consensus (subnetactor.ConsensusType) (uint64)
+
 	{
-		maj, extra, err := cr.ReadHeader()
-		var extraI int64
+
+		maj, extra, err = cr.ReadHeader()
 		if err != nil {
 			return err
 		}
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative oveflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
 		}
+		t.Consensus = ConsensusType(extra)
 
-		t.Consensus = ConsensusType(extraI)
 	}
 	// t.MinValidatorStake (big.Int) (struct)
 

--- a/subnetactor/cbor_gen.go
+++ b/subnetactor/cbor_gen.go
@@ -452,9 +452,9 @@ func (t *ConstructParams) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.IpcGatewayAddr (uint64) (uint64)
+	// t.IPCGatewayAddr (uint64) (uint64)
 
-	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.IpcGatewayAddr)); err != nil {
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.IPCGatewayAddr)); err != nil {
 		return err
 	}
 
@@ -554,7 +554,7 @@ func (t *ConstructParams) UnmarshalCBOR(r io.Reader) (err error) {
 
 		t.Name = string(sval)
 	}
-	// t.IpcGatewayAddr (uint64) (uint64)
+	// t.IPCGatewayAddr (uint64) (uint64)
 
 	{
 
@@ -565,7 +565,7 @@ func (t *ConstructParams) UnmarshalCBOR(r io.Reader) (err error) {
 		if maj != cbg.MajUnsignedInt {
 			return fmt.Errorf("wrong type for uint64 field")
 		}
-		t.IpcGatewayAddr = uint64(extra)
+		t.IPCGatewayAddr = uint64(extra)
 
 	}
 	// t.Consensus (subnetactor.ConsensusType) (uint64)

--- a/subnetactor/subnet-actor.go
+++ b/subnetactor/subnet-actor.go
@@ -62,5 +62,4 @@ func (st *State) HasMajorityVote(s adt.Store, v Votes) (bool, error) {
 	div := new(mbig.Rat).SetFrac(fsum.Num(), fTotal.Num())
 	threshold := utils.MajorityThreshold()
 	return div.Cmp(&threshold) >= 0, nil
-
 }

--- a/subnetactor/types.go
+++ b/subnetactor/types.go
@@ -19,7 +19,7 @@ type Validator struct {
 type ConstructParams struct {
 	Parent            sdk.SubnetID
 	Name              string
-	IpcGatewayAddr    uint64
+	IPCGatewayAddr    uint64
 	Consensus         ConsensusType
 	MinValidatorStake abi.TokenAmount
 	MinValidators     uint64

--- a/subnetactor/types.go
+++ b/subnetactor/types.go
@@ -1,9 +1,10 @@
 package subnetactor
 
 import (
-	"github.com/consensus-shipyard/go-ipc-types/sdk"
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+
+	"github.com/consensus-shipyard/go-ipc-types/sdk"
 )
 
 // ManifestID is the id used to index the gateway actor

--- a/subnetactor/types.go
+++ b/subnetactor/types.go
@@ -37,7 +37,7 @@ type Votes struct {
 
 // ConsensusType defines the types of consensus supported
 // by subnets.
-type ConsensusType int64
+type ConsensusType uint64
 
 const (
 	Delegated ConsensusType = iota

--- a/utils/serialization_test.go
+++ b/utils/serialization_test.go
@@ -25,7 +25,7 @@ func TestCborSerialization(t *testing.T) {
 	params := subnetactor.ConstructParams{
 		Parent:            sdk.RootSubnet,
 		Name:              "test",
-		IpcGatewayAddr:    64,
+		IPCGatewayAddr:    64,
 		CheckPeriod:       0,
 		FinalityThreshold: 0,
 		MinValidators:     0,

--- a/utils/serialization_test.go
+++ b/utils/serialization_test.go
@@ -16,7 +16,7 @@ import (
 // TestCborSerialization cbor-serializes a specific type and prints in a log
 // the hex representation of the serialization.
 //
-// This is really helpful when debuggin the serialization interop between Go
+// This is really helpful when debugging the serialization interop between Go
 // and Rust, as the serialization can be input in tools like https://cbor.me/
 // to inspect the result that was actually serialized.
 // This is an example with subnetactor.ConstructParams, but it can be done

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -12,7 +12,7 @@ import (
 	"github.com/filecoin-project/specs-actors/v7/actors/util/adt"
 )
 
-func GetOutOfAdtArray[T any](adtArray *adt.Array, nonce uint64) (*T, error) {
+func GetOutOfAdtArray[T any](adtArray *adt.Array, nonce uint64) (*T, bool, error) {
 	var (
 		out   T
 		found bool
@@ -22,48 +22,54 @@ func GetOutOfAdtArray[T any](adtArray *adt.Array, nonce uint64) (*T, error) {
 	if i, ok := (any(&out)).(cbor.Unmarshaler); ok {
 		found, err = adtArray.Get(nonce, i)
 	} else {
-		return nil, fmt.Errorf("the type *%T does not implement the cbor.Unmarshaler interface", out)
+		return nil, false, fmt.Errorf("the type *%T does not implement the cbor.Unmarshaler interface", out)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to get %T with nonce %v: %w", out, nonce, err)
+		return nil, false, fmt.Errorf("failed to get %T with nonce %v: %w", out, nonce, err)
 	}
 	if !found {
-		return nil, nil
+		return nil, false, nil
 	}
-	return &out, nil
+	return &out, true, nil
 }
 
 // GetOutOfArray takes a generic type that must implement cbor.Unmarshaler
 // and returns a particular vale of a TAmt type passed as cid.Cid given the nonce
 // If the type does not implement cbor.Unmarshaler then this returns an error at runtime
-func GetOutOfArray[T any](cID cid.Cid, s adt.Store, nonce uint64, bitwidth int) (*T, error) {
+func GetOutOfArray[T any](cID cid.Cid, s adt.Store, nonce uint64, bitwidth int) (*T, bool, error) {
 	adtArray, err := adt.AsArray(s, cID, bitwidth)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	out, err := GetOutOfAdtArray[T](adtArray, nonce)
+	out, found, err := GetOutOfAdtArray[T](adtArray, nonce)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return out, nil
+	return out, found, nil
 }
 
 // GetOutOfHamt takes a generic type that must implement cbor.Unmarshaler
 // and returns a particular value of a THamt type passed as cid.Cid given the key
 // If the type does not implement cbor.Unmarshaler then this returns an error at runtime
-func GetOutOfHamt[T any](cID cid.Cid, s adt.Store, k abi.Keyer) (*T, error) {
+func GetOutOfHamt[T any](cID cid.Cid, s adt.Store, k abi.Keyer) (*T, bool, error) {
 	var out T
 	adtMap, err := adt.AsMap(s, cID, builtin.DefaultHamtBitwidth)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get stake: %w", err)
+		return nil, false, fmt.Errorf("failed to get stake: %w", err)
 	}
 
 	if i, ok := (any(&out)).(cbor.Unmarshaler); ok {
-		_, err = adtMap.Get(k, i)
+		found, err := adtMap.Get(k, i)
+		if err != nil {
+			return nil, false, err
+		}
+		if !found {
+			return nil, false, nil
+		}
 	} else {
-		return nil, fmt.Errorf("the type *%T does not implement the cbor.Unmarshaler interface", out)
+		return nil, false, fmt.Errorf("the type *%T does not implement the cbor.Unmarshaler interface", out)
 	}
-	return &out, err
+	return &out, true, nil
 }
 
 func MajorityThreshold() mbig.Rat {


### PR DESCRIPTION
This PR: 
- Fixes subnet serialization.
- Includes a explicit check to HAMT and AMT functions for when there are no errors but the key doesn't exist.
- Implements state accessors for checkpoints. 
- Implements CID computation for checkpoints.