### PR TITLE
fix: serialization of validator set

### DIFF
--- a/gateway/cbor_gen.go
+++ b/gateway/cbor_gen.go
@@ -8,12 +8,11 @@ import (
 	"math"
 	"sort"
 
+	sdk "github.com/consensus-shipyard/go-ipc-types/sdk"
+	abi "github.com/filecoin-project/go-state-types/abi"
 	cid "github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
-
-	sdk "github.com/consensus-shipyard/go-ipc-types/sdk"
-	abi "github.com/filecoin-project/go-state-types/abi"
 )
 
 var _ = xerrors.Errorf

--- a/subnetactor/cbor_gen.go
+++ b/subnetactor/cbor_gen.go
@@ -8,14 +8,13 @@ import (
 	"math"
 	"sort"
 
-	cid "github.com/ipfs/go-cid"
-	cbg "github.com/whyrusleeping/cbor-gen"
-	xerrors "golang.org/x/xerrors"
-
 	sdk "github.com/consensus-shipyard/go-ipc-types/sdk"
 	validator "github.com/consensus-shipyard/go-ipc-types/validator"
 	address "github.com/filecoin-project/go-address"
 	abi "github.com/filecoin-project/go-state-types/abi"
+	cid "github.com/ipfs/go-cid"
+	cbg "github.com/whyrusleeping/cbor-gen"
+	xerrors "golang.org/x/xerrors"
 )
 
 var _ = xerrors.Errorf

--- a/validator/cbor_gen.go
+++ b/validator/cbor_gen.go
@@ -8,11 +8,10 @@ import (
 	"math"
 	"sort"
 
+	big "github.com/filecoin-project/go-state-types/big"
 	cid "github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
-
-	big "github.com/filecoin-project/go-state-types/big"
 )
 
 var _ = xerrors.Errorf
@@ -136,12 +135,6 @@ func (t *Set) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.ConfigurationNumber (uint64) (uint64)
-
-	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.ConfigurationNumber)); err != nil {
-		return err
-	}
-
 	// t.Validators ([]*validator.Validator) (slice)
 	if len(t.Validators) > cbg.MaxLength {
 		return xerrors.Errorf("Slice value in field t.Validators was too long")
@@ -155,6 +148,13 @@ func (t *Set) MarshalCBOR(w io.Writer) error {
 			return err
 		}
 	}
+
+	// t.ConfigurationNumber (uint64) (uint64)
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.ConfigurationNumber)); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -181,20 +181,6 @@ func (t *Set) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.ConfigurationNumber (uint64) (uint64)
-
-	{
-
-		maj, extra, err = cr.ReadHeader()
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.ConfigurationNumber = uint64(extra)
-
-	}
 	// t.Validators ([]*validator.Validator) (slice)
 
 	maj, extra, err = cr.ReadHeader()
@@ -224,5 +210,19 @@ func (t *Set) UnmarshalCBOR(r io.Reader) (err error) {
 		t.Validators[i] = &v
 	}
 
+	// t.ConfigurationNumber (uint64) (uint64)
+
+	{
+
+		maj, extra, err = cr.ReadHeader()
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.ConfigurationNumber = uint64(extra)
+
+	}
 	return nil
 }

--- a/validator/validator_set.go
+++ b/validator/validator_set.go
@@ -18,8 +18,8 @@ import (
 )
 
 type Set struct {
-	ConfigurationNumber uint64       `json:"configuration_number"`
 	Validators          []*Validator `json:"validators"`
+	ConfigurationNumber uint64       `json:"configuration_number"`
 }
 
 // NewValidatorSetFromFile reads a validator set based from the file.


### PR DESCRIPTION
There was an inconsistency in the de/serialization of the `ValidatorSet` between Rust and Go, and the reason is that as the CBOR serialization used for actor state is of type `tuple`, all of the fields of a struct need to come in a right order as they are not serialized in a map and indexed by name. 

This PR fixes the `ValidatorSet` to use the right order in its serialization expected by the subnet actor state in Rust. 