### PR TITLE
Epoch encoding for HAMT keys

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -32,8 +32,8 @@ func (st *State) GetSubnet(s adt.Store, id sdk.SubnetID) (*Subnet, bool, error) 
 	return utils.GetOutOfHamt[Subnet](st.Subnets, s, id)
 }
 
-func (st *State) GetCheckpoints(s adt.Store, c abi.ChainEpoch) (*Checkpoint, bool, error) {
-	return utils.GetOutOfHamt[Checkpoint](st.Checkpoints, s, abi.UIntKey(uint64(c)))
+func (st *State) GetCheckpoints(s adt.Store, e abi.ChainEpoch) (*Checkpoint, bool, error) {
+	return utils.GetOutOfHamt[Checkpoint](st.Checkpoints, s, sdk.EpochKey(e))
 }
 
 func (st *State) GetCrossMsgs(s adt.Store, cID cid.Cid) (*CrossMsgs, bool, error) {

--- a/sdk/types.go
+++ b/sdk/types.go
@@ -1,5 +1,11 @@
 package sdk
 
+import (
+	"encoding/binary"
+
+	"github.com/filecoin-project/go-state-types/abi"
+)
+
 // Status defines the different states in which a subnet can be.
 type Status int64
 
@@ -10,3 +16,12 @@ const (
 	Terminating
 	Killed
 )
+
+type EpochKey abi.ChainEpoch
+
+func (k EpochKey) Key() string {
+	// varInt integer encoding
+	buf := make([]byte, binary.MaxVarintLen64)
+	n := binary.PutVarint(buf, int64(k))
+	return string(buf[:n])
+}

--- a/subnetactor/subnet-actor.go
+++ b/subnetactor/subnet-actor.go
@@ -46,7 +46,7 @@ func (st *State) GetStake(s adt.Store, id address.Address) (abi.TokenAmount, err
 }
 
 func (st *State) GetCheckpoint(s adt.Store, epoch abi.ChainEpoch) (*gateway.Checkpoint, bool, error) {
-	return utils.GetOutOfHamt[gateway.Checkpoint](st.Stake, s, abi.UIntKey(uint64(epoch)))
+	return utils.GetOutOfHamt[gateway.Checkpoint](st.Checkpoints, s, sdk.EpochKey(epoch))
 }
 
 func (st *State) GetCheckpointVotes(s adt.Store, checkCid cid.Cid) (*Votes, bool, error) {


### PR DESCRIPTION
This PR introduces the use of a varInt to encode the epoch when used as a key from a HAMT. This ensure its compatibility with how HAMT keys are encoded in Rust.