### PR TITLE
add voting submission serialization and accessors

### DIFF
--- a/gen/gen.go
+++ b/gen/gen.go
@@ -62,6 +62,7 @@ func main() {
 	if err := gen.WriteTupleEncodersToFile("./voting/cbor_gen.go", "voting",
 		voting.Voting{},
 		voting.Ratio{},
+		voting.EpochVoteSubmissions{},
 	); err != nil {
 		panic(err)
 	}

--- a/subnetactor/subnet-actor.go
+++ b/subnetactor/subnet-actor.go
@@ -52,11 +52,6 @@ func (st *State) GetCheckpoint(s adt.Store, epoch abi.ChainEpoch) (*gateway.Bott
 	return utils.GetOutOfHamt[gateway.BottomUpCheckpoint](st.CommittedCheckpoints, s, sdk.EpochKey(epoch))
 }
 
-func (st *State) GetCheckpointVotes(_ adt.Store, _ cid.Cid) (*Votes, bool, error) {
-	// return utils.GetOutOfHamt[Votes](st.WindowChecks, s, abi.CidKey(checkCid))
-	panic("function not implemented")
-}
-
 func (st *State) HasMajorityVote(s adt.Store, v Votes) (bool, error) {
 	sum := big.Zero()
 	for _, m := range v.Validators {

--- a/voting/voting.go
+++ b/voting/voting.go
@@ -1,6 +1,9 @@
 package voting
 
 import (
+	"github.com/consensus-shipyard/go-ipc-types/sdk"
+	"github.com/consensus-shipyard/go-ipc-types/utils"
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/specs-actors/v7/actors/util/adt"
 	"github.com/ipfs/go-cid"
@@ -38,4 +41,36 @@ func NewWithRatio(store adt.Store, genesis, period abi.ChainEpoch, ratio Ratio) 
 		EpochVoteSubmission:  emptyMapCid,
 		Ratio:                ratio,
 	}, nil
+}
+
+// EpochVoteSubmissions tracks all the vote submissions of an epoch
+// for a checkpoint voting.
+type EpochVoteSubmissions struct {
+	TotalSubmissionWeight abi.TokenAmount
+	MostVotedKey          []byte
+	Submitters            cid.Cid // TCid<THamt<Address, ()>>
+	SubmissionWeights     cid.Cid // TCid<THamt<UniqueBytesKey, TokenAmount>>
+	Submissions           cid.Cid // TCid<THamt<UniqueBytesKey, T>>
+}
+
+// ValidatorHasVoted checks if a validator has already voted for a checkpoint.
+//
+// This function expects the ID (f0 address) of the validator address, which is the
+// one used to index validators in the actor state. f1 and f3 addresses will have to
+// be translated to f0 addresses before using this function.
+func (v *Voting) ValidatorHasVoted(s adt.Store, epoch abi.ChainEpoch, validator address.Address) (bool, error) {
+	sub, found, err := utils.GetOutOfHamt[EpochVoteSubmissions](v.EpochVoteSubmission, s, sdk.EpochKey(epoch))
+	if err != nil {
+		return false, err
+	}
+	// if no submission found we don't error, we consider that no validator
+	// has voted yet.
+	if !found {
+		return false, nil
+	}
+	_, found, err = utils.GetOutOfHamt[interface{}](sub.Submitters, s, abi.AddrKey(validator))
+	if err != nil {
+		return false, err
+	}
+	return found, nil
 }


### PR DESCRIPTION
This PR introduces the serialization of the `EpochVoteSubmissions` and a `Voting` accessor to determine if a validator has already voted to a checkpoint for certain epoch or not. 

@cryptoAtwill, do you mind having a look before merging to double-check if I am doing it write (mainly I want you to check the `ValidatorHasVoted` function. Also, I am afraid that for this to work we will need `MostVotedKey` to be serialized as an empty vector if `None`, and to use `serde_bytes` for a serialization, if not we will start seeing serialization issues again: https://github.com/consensus-shipyard/ipc-actors/blob/5ef2203f5af2a736d91771bccabe1e663ee719d8/common/src/vote/submission.rs#L23