### PR TITLE
Fix TopDownMsg serialization

### DIFF
--- a/gateway/types.go
+++ b/gateway/types.go
@@ -72,7 +72,7 @@ type StorableMsg struct {
 	From   sdk.IPCAddress
 	To     sdk.IPCAddress
 	Method abi.MethodNum
-	Params RawBytes
+	Params []byte
 	Value  abi.TokenAmount
 	Nonce  uint64
 }
@@ -97,10 +97,6 @@ type IPCMsgType int
 type ConstructParams struct {
 	NetworkName      string
 	CheckpointPeriod abi.ChainEpoch
-}
-
-type RawBytes struct {
-	Bytes []byte
 }
 
 type CrossMsg struct {

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -22,7 +22,6 @@ func main() {
 		gateway.BatchCrossMsgs{},
 		gateway.StorableMsg{},
 		gateway.Subnet{},
-		gateway.RawBytes{},
 		gateway.CrossMsg{},
 		gateway.FundParams{},
 		gateway.CrossMsgParams{},


### PR DESCRIPTION
Fixes a bug for which the params were not being serialized correctly. 